### PR TITLE
Handling incorrect gzip fixed

### DIFF
--- a/lib/logstash/codecs/json_gz.rb
+++ b/lib/logstash/codecs/json_gz.rb
@@ -77,6 +77,7 @@ class LogStash::Codecs::JsonGz < LogStash::Codecs::Base
     gz.read
   rescue Zlib::Error, Zlib::GzipFile::Error => e
     @logger.error("Error decompressing gzip data: #{e}")
+    raise
   end
 
 end # class LogStash::Codecs::JsonGz


### PR DESCRIPTION
Currently, when an incorrect gzip is being decoded, the following happens:
1. Codec calls `decompress` method.
2. `decompress` calls `GzipReader.read`, which throws an error.
3. An error is caught by `decompress` method; `decompress` returns logger object (since it's the last statement).
4. Codec tries to proceed with logger object as data which causes an unrecoverable error.

My commit changes this behaviour; decompression errors are propagated to the `decode` method and the codec stops processing upon catching them and passes the original data further on.